### PR TITLE
fix hardhat-ethers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@gnosis.pm/safe-core-sdk-types": "^1.0.0",
     "@gnosis.pm/safe-ethers-lib": "^1.0.0",
     "@gnosis.pm/safe-service-client": "1.1.1",
-    "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.13",
+    "@nomiclabs/hardhat-ethers": "^2.2.3",
     "dotenv": "^16.0.3",
     "ethers": "^5.5.2",
     "hardhat": "2.12.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,10 +852,10 @@
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.1.1"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.1"
 
-"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers@0.3.0-beta.13":
-  version "0.3.0-beta.13"
-  resolved "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz#b96086ff768ddf69928984d5eb0a8d78cfca9366"
-  integrity sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==
+"@nomiclabs/hardhat-ethers@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz#b41053e360c31a32c2640c9a45ee981a7e603fe0"
+  integrity sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==
 
 "@oclif/core@^1.1.1":
   version "1.26.2"


### PR DESCRIPTION
Historically, an alternate version of hardhat-ethers was utilized in order to allow inclusion of
hardhat-toolbox.  For more information, reference:

https://github.com/wighawag/hardhat-deploy-ethers/issues/27

Since hardhat-toolbox is no longer used, and the original problem has been resolved anyway, fix
to the latest version (^2.2.3):

https://www.npmjs.com/package/@nomiclabs/hardhat-ethers?activeTab=versions

Signed-off-by: Ryan Goulding <goulding@layerzerolabs.org>
