### PR TITLE
feat:  specify addresses in config generation instead of reading from…

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,66 @@
+import { HardhatUserConfig } from "hardhat/config";
+
+import "./src/index"
+
+// This adds support for typescript paths mappings
+import "tsconfig-paths/register";
+
+const config: HardhatUserConfig = {
+    networks: {
+        'sepolia-testnet': {
+            url: 'https://eth-sepolia.public.blastapi.io'
+        },
+        'bsc-testnet': {
+            url: 'https://data-seed-prebsc-1-s1.bnbchain.org:8545'
+        },
+        'avalanche-testnet': {
+            url: 'https://ava-testnet.public.blastapi.io/ext/bc/C/rpc'
+        },
+        'idex-testnet': {
+            url: 'https://rpc-devnet-idex.hardfork.dev'
+        },
+
+
+        'ethereum-mainnet': {
+            url: 'https://eth.llamarpc.com'
+        },
+        'bsc-mainnet': {
+            url: 'https://binance.llamarpc.com'
+        },
+        'avalanche-mainnet': {
+            url: 'https://api.avax.network/ext/bc/C/rpc'
+        },
+        'polygon-mainnet': {
+            url: 'https://polygon.llamarpc.com'
+        },
+        'arbitrum-mainnet': {
+            url: 'https://arbitrum.llamarpc.com'
+        },
+        'optimism-mainnet': {
+            url: 'https://mainnet.optimism.io'
+        },
+        'fantom-mainnet': {
+            url: 'https://fantom-mainnet.public.blastapi.io'
+        },
+        'base-mainnet': {
+            url: 'https://base.llamarpc.com'
+        },
+        'kava-mainnet': {
+            url: 'https://kava-evm.publicnode.com'
+        },
+        'mantle-mainnet': {
+            url: 'https://1rpc.io/mantle'
+        },
+        'metis-mainnet': {
+            url: 'https://metis-mainnet.public.blastapi.io'
+        },
+        'scroll-mainnet': {
+            url: 'https://rpc.scroll.io'
+        },
+        'zkconsensys-mainnet': {
+            url: 'https://1rpc.io/linea'
+        }
+    }
+};
+
+export default config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ task("getDefaultConfig", "outputs the default Send and Receive Messaging Library
 
 task("generateAppConfig", "generates the config mesh for a User Application", generateAppConfigAction)
 	.addParam("networks", "comma separated list of networks")
-	.addParam('name', 'name of the deployed contract. Should be specified only if the deployment information is located in the deployments folder')
+	.addParam("name", "name of the deployed contract. Should be specified only if the deployment information is located in the deployments folder")
 	.addOptionalParam("outputFileName", "the path to the output file", "./constants/defaultConfig.json", types.string)
 	.addOptionalParam("checkConnectionFunctionFragment", "the checkConnection function fragment", LZ_APP_TRUSTED_REMOTE_LOOKUP_FUNCTION_FRAGMENT, types.string)
 


### PR DESCRIPTION
… deployments

Allows one to run config generation tool completely separate of importing the ua-utils tool to the target repository.