### PR TITLE
more descriptive error messages

### DIFF
--- a/src/utils/crossChainHelper.ts
+++ b/src/utils/crossChainHelper.ts
@@ -332,17 +332,22 @@ export const getEndpointAddress = (network: string): string => { return LZ_ENDPO
 
 // expecting "chain-environment" eg. "ethereum-mainnet", "ethereum-testnet", "ethereum-sandbox"
 export const getLayerZeroChainId = (network: string): string => {
-    const [chainName, environment] = network.split("-");
-    const chainIdEnum = getChainIdEnum(chainName, environment)
-    if(environment == "mainnet") {
-        return MainnetEndpointId[chainIdEnum as any]
-    } else if(environment == "testnet") {
-        return TestnetEndpointId[chainIdEnum as any]
-    }  else if(environment == "sandbox") {
-        return SandboxEndpointId[chainIdEnum as any]
-    } else {
-        throw new Error("cannot find chainId");
-    }
+	const tmp = network.split("-");
+	if (tmp.length <= 1) {
+		throw new Error("cannot parse chain '" + network + "'. should be in the format '<chain-name>_<mainnet|testnet>' ")
+	}
+	const [chainName, environment] = tmp;
+
+	const chainIdEnum = getChainIdEnum(chainName, environment)
+	if (environment == "mainnet") {
+		return MainnetEndpointId[chainIdEnum as any]
+	} else if (environment == "testnet") {
+		return TestnetEndpointId[chainIdEnum as any]
+	} else if (environment == "sandbox") {
+		return SandboxEndpointId[chainIdEnum as any]
+	} else {
+		throw new Error("cannot find chainId for chain '" + chainName + "' and environment '" + environment + "'");
+	}
 }
 
 const getChainIdEnum = (chainName: string, environment: string,): string => {


### PR DESCRIPTION
Without this I was just getting generic errors like this (cause it wasn't abel to split):

```
TypeError: Cannot read properties of undefined (reading 'utils')
```